### PR TITLE
Make saxonche an optional dependency

### DIFF
--- a/doclang/schematron_validation.py
+++ b/doclang/schematron_validation.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Union
 
 from lxml import etree
-from saxonche import PySaxonProcessor
 
 from doclang._schemas import _bundled_sch_path
 from doclang.utils import _ensure_namespace
@@ -117,6 +116,13 @@ def _transpile_schematron_to_xslt(sch_file, verbose=False):
     if verbose:
         print(f"Transpiling Schematron: {sch_file}")
 
+    try:
+        from saxonche import PySaxonProcessor
+    except ImportError:
+        raise ImportError(
+            "saxonche is required for Schematron validation. Install it with: pip install doclang[schematron]"
+        ) from None
+
     with PySaxonProcessor(license=False) as proc:
         xslt_proc = proc.new_xslt30_processor()
 
@@ -162,6 +168,13 @@ def _validate_with_schematron(
             tmp_xml_path = tmp.name
 
             # File is still open but flushed, Saxon can read it
+            try:
+                from saxonche import PySaxonProcessor
+            except ImportError:
+                raise ImportError(
+                    "saxonche is required for Schematron validation. Install it with: pip install doclang[schematron]"
+                ) from None
+
             with PySaxonProcessor(license=False) as proc:
                 if verbose:
                     print(f"Using XSLT processor version: {proc.version}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,11 @@ classifiers = [
 ]
 dependencies = [
     "lxml>=6.0.2",
-    "saxonche>=12.9.0",
     "typer>=0.15.1",
 ]
+
+[project.optional-dependencies]
+schematron = ["saxonche>=12.9.0"]
 
 [project.urls]
 Homepage = "https://www.doclang.ai/"

--- a/uv.lock
+++ b/uv.lock
@@ -355,8 +355,12 @@ version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },
-    { name = "saxonche" },
     { name = "typer" },
+]
+
+[package.optional-dependencies]
+schematron = [
+    { name = "saxonche" },
 ]
 
 [package.dev-dependencies]
@@ -382,9 +386,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "lxml", specifier = ">=6.0.2" },
-    { name = "saxonche", specifier = ">=12.9.0" },
+    { name = "saxonche", marker = "extra == 'schematron'", specifier = ">=12.9.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
+provides-extras = ["schematron"]
 
 [package.metadata.requires-dev]
 ci = [


### PR DESCRIPTION
saxonche (Saxon/C XSLT processor bindings) is only needed for Schematron validation but is declared as a hard dependency, which means it is always installed.

This is problematic becaus saxonche does not have a source distribution on PyPI, does not publish wheels for ppc64le or s390x architectures, and uses a non-standard git forge
(https://saxonica.plan.io/projects/saxonmirrorhe/repository); the mirror at https://github.com/Saxonica/Saxon-HE does not publish any build infrastructure. All of this means makes doclang uninstallable on the aforementioned architectures or systems that require building dependencies from source.

This changes moves saxonche from core dependencies to an optional extra (`pip install doclang[schematron]`) and lazy-load it in the two functions that use it. All other doclang functionality (packaging, XSD validation, serialization, deserialization) works without saxonche installed.