### PR TITLE
add pluggable Schematron validation backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ directory.
 
 ## Reference Toolkit
 
-You can install the toolkit from PyPI:
+The commands below illustrate basic scenarios. For advanced installation and usage options
+(minimal install, platform notes, custom Schematron backends, Python API), see the
+[toolkit README](https://github.com/doclang-project/doclang/blob/main/doclang/README.md).
+
+### Installation
 
 ```bash
-pip install doclang
+pip install "doclang[schematron-saxon]"
 ```
 
 ### Validation
@@ -43,8 +47,6 @@ doclang validate -n my_document.dclg
 ```bash
 doclang pack my_document.dclg
 ```
-
-For more details, see the [doclang/README.md](https://github.com/doclang-project/doclang/blob/main/doclang/README.md).
 
 ## Citation
 

--- a/doclang/README.md
+++ b/doclang/README.md
@@ -4,9 +4,22 @@ Official Python toolkit for working with DocLang — CLI commands and library AP
 
 ## Installation
 
+Recommended — full validation (XSD + Schematron):
+
+```bash
+pip install "doclang[schematron-saxon]"
+```
+
+Minimal install without Schematron (packaging, XSD-only validation, or platforms where
+`saxonche` has no wheel — e.g. Windows on ARM64, ppc64le, s390x):
+
 ```bash
 pip install doclang
 ```
+
+On a minimal install, pass `xsd_only=True` for XSD-only validation, or supply a custom
+`schematron=` backend. Default `validate()` expects a Schematron backend and raises
+`SchematronBackendNotFound` when none is available.
 
 ## CLI
 
@@ -71,6 +84,50 @@ except ValidationError as exc:
     print(f"{exc.schematron_errors=}")
 ```
 
+### Custom Schematron backends
+
+DocLang does not bundle a single Schematron runtime in the core package. Instead,
+`validate()` accepts an optional Schematron engine via the `schematron` parameter.
+When omitted, the default Saxon/C backend is used (requires `doclang[schematron-saxon]`).
+
+To plug in your own engine, implement the `SchematronValidator` protocol and return
+`SchematronViolation` objects — one per failed rule:
+
+```python
+from pathlib import Path
+
+from doclang import SchematronViolation, validate
+
+
+class MySchematronValidator:
+    def validate(
+        self,
+        xml_path: Path,
+        *,
+        schema_path: Path,
+        allow_empty_namespace: bool = False,
+    ) -> list[SchematronViolation]:
+        # Run your engine against schema_path (bundled doclang.sch) and xml_path.
+        # Map failures to SchematronViolation(location=..., message=...).
+        ...
+
+validate("my_document.dclg", schematron=MySchematronValidator())
+```
+
+Notes for implementers:
+
+- `schema_path` points at the bundled `doclang.sch` rules (XPath 3.1 / `queryBinding="xslt3"`).
+- Set `allow_empty_namespace=True` when the XML may lack the DocLang namespace; the
+  default Saxon backend injects it before validation — custom backends should do the same
+  if they operate on file paths rather than pre-processed trees.
+- Use `xsd_only=True` on `validate()` when your application does not need Schematron at all.
+
+**Example:** [pyschematron](https://pypi.org/project/pyschematron/) is a pure-Python
+Schematron evaluator you can wrap in a `SchematronValidator` and install separately in
+your own project (doclang does not ship or endorse it as a dependency). Similar adapters
+can be built for any engine that evaluates ISO Schematron or consumes a precompiled XSLT
+stylesheet derived from `doclang.sch`.
+
 ### Packaging
 
 ```python
@@ -106,7 +163,9 @@ Additional business rules that XSD cannot express, using XSLT 3.0 and XPath 3.1:
 </sch:pattern>
 ```
 
-The validation uses XSLT 3.0 for modern XPath features.
+The bundled Saxon/C backend transpiles these rules to XSLT 3.0 at validation time.
+Alternative backends may evaluate the same `.sch` file directly or use a precompiled
+`.xsl` artifact if their runtime requires it.
 
 ## XSD Validation with VS Code
 

--- a/doclang/__init__.py
+++ b/doclang/__init__.py
@@ -1,6 +1,15 @@
 """DocLang reference toolkit."""
 
 from doclang.packaging import PackagingError, pack
+from doclang.schematron import SchematronBackendNotFound, SchematronValidator, SchematronViolation
 from doclang.validation import ValidationError, validate
 
-__all__ = ["PackagingError", "ValidationError", "pack", "validate"]
+__all__ = [
+    "PackagingError",
+    "SchematronBackendNotFound",
+    "SchematronValidator",
+    "SchematronViolation",
+    "ValidationError",
+    "pack",
+    "validate",
+]

--- a/doclang/backends/__init__.py
+++ b/doclang/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Optional Schematron validation backends."""

--- a/doclang/backends/_svrl.py
+++ b/doclang/backends/_svrl.py
@@ -1,0 +1,25 @@
+"""SVRL parsing helpers for Schematron backends."""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from doclang.schematron import SchematronViolation
+
+_SVRL_NS = "http://purl.oclc.org/dsdl/svrl"
+
+
+def _failed_assert_to_violation(assert_elem: etree._Element) -> SchematronViolation:
+    text_elem = assert_elem.find(f"{{{_SVRL_NS}}}text")
+    message = text_elem.text if text_elem is not None and text_elem.text else "No message"
+    return SchematronViolation(
+        location=assert_elem.get("location"),
+        message=message,
+        rule_id=assert_elem.get("id"),
+        test=assert_elem.get("test"),
+    )
+
+
+def _svrl_failed_asserts_to_violations(svrl_root: etree._Element) -> list[SchematronViolation]:
+    failed_asserts = svrl_root.findall(f".//{{{_SVRL_NS}}}failed-assert")
+    return [_failed_assert_to_violation(elem) for elem in failed_asserts]

--- a/doclang/backends/saxonche.py
+++ b/doclang/backends/saxonche.py
@@ -1,17 +1,18 @@
 """
-Schematron validation utilities for DocLang.
+Saxon/C (saxonche) Schematron validation backend.
 
-This module provides Schematron validation by transpiling .sch files to XSLT
-on-the-fly using XSLT 3.0 / XPath 3.1.
+Transpiles .sch files to XSLT on-the-fly using XSLT 3.0 / XPath 3.1.
 """
+
+from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import Union
 
 from lxml import etree
 
-from doclang._schemas import _bundled_sch_path
+from doclang.backends._svrl import _svrl_failed_asserts_to_violations
+from doclang.schematron import SchematronViolation, _require_saxonche_backend
 from doclang.utils import _ensure_namespace
 
 # ISO Schematron transpiler - converts .sch to XSLT 3.0
@@ -102,34 +103,16 @@ _ISO_SCHEMATRON_TRANSPILER = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-def _transpile_schematron_to_xslt(sch_file, verbose=False):
-    """
-    Transpile Schematron (.sch) to XSLT 3.0 on-the-fly.
+def _transpile_schematron_to_xslt(sch_file: Path, *, verbose: bool = False) -> str:
+    _require_saxonche_backend()
+    from saxonche import PySaxonProcessor
 
-    Args:
-        sch_file: Path to Schematron file
-        verbose: Print progress messages
-
-    Returns:
-        str: Generated XSLT stylesheet as string
-    """
     if verbose:
         print(f"Transpiling Schematron: {sch_file}")
 
-    try:
-        from saxonche import PySaxonProcessor
-    except ImportError:
-        raise ImportError(
-            "saxonche is required for Schematron validation. Install it with: pip install doclang[schematron]"
-        ) from None
-
     with PySaxonProcessor(license=False) as proc:
         xslt_proc = proc.new_xslt30_processor()
-
-        # Compile the transpiler
         xslt_executable = xslt_proc.compile_stylesheet(stylesheet_text=_ISO_SCHEMATRON_TRANSPILER)
-
-        # Transform Schematron to XSLT
         result = xslt_executable.transform_to_string(source_file=str(sch_file))
 
         if not result:
@@ -138,83 +121,57 @@ def _transpile_schematron_to_xslt(sch_file, verbose=False):
         return result
 
 
-def _validate_with_schematron(
-    xml_file: Union[str, Path],
-    allow_empty_namespace: bool = False,
-    verbose: bool = False,
-) -> list:
-    """Validate XML against the bundled DocLang Schematron rules.
+class SaxoncheValidator:
+    """Schematron validator backed by Saxon/C (saxonche)."""
 
-    Returns:
-        SVRL failed-assert elements; empty when validation passes.
-    """
-    sch_file = _bundled_sch_path()
-    if verbose:
-        print(f"Using Schematron file: {sch_file}")
+    def validate(
+        self,
+        xml_path: Path,
+        *,
+        schema_path: Path,
+        allow_empty_namespace: bool = False,
+        verbose: bool = False,
+    ) -> list[SchematronViolation]:
+        _require_saxonche_backend()
+        from saxonche import PySaxonProcessor
 
-    try:
-        # Load and optionally ensure namespace
-        with open(xml_file, "rb") as f:
+        if verbose:
+            print(f"Using Schematron file: {schema_path}")
+
+        with open(xml_path, "rb") as f:
             xml_doc = etree.parse(f)
 
         if allow_empty_namespace:
             xml_doc = _ensure_namespace(xml_doc)
 
-        # Write to temporary file for Saxon processing
-        # Note: delete=True (default) but we need to close before Saxon can read
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".xml", delete=True) as tmp:
             xml_doc.write(tmp, encoding="utf-8", xml_declaration=True)
-            tmp.flush()  # Ensure data is written
+            tmp.flush()
             tmp_xml_path = tmp.name
-
-            # File is still open but flushed, Saxon can read it
-            try:
-                from saxonche import PySaxonProcessor
-            except ImportError:
-                raise ImportError(
-                    "saxonche is required for Schematron validation. Install it with: pip install doclang[schematron]"
-                ) from None
 
             with PySaxonProcessor(license=False) as proc:
                 if verbose:
                     print(f"Using XSLT processor version: {proc.version}")
 
-                # Get XSLT 3.0 processor (supports XPath 3.1)
                 xslt_proc = proc.new_xslt30_processor()
 
-                # Transpile Schematron to XSLT
                 if verbose:
                     print("Transpiling Schematron to XSLT 3.0...")
 
-                xslt_text = _transpile_schematron_to_xslt(sch_file, verbose=verbose)
+                xslt_text = _transpile_schematron_to_xslt(schema_path, verbose=verbose)
 
-                # Compile the generated XSLT stylesheet
                 if verbose:
                     print("Compiling generated XSLT...")
 
                 xslt_executable = xslt_proc.compile_stylesheet(stylesheet_text=xslt_text)
 
-                # Transform XML
                 if verbose:
                     print("Executing Schematron validation...")
 
                 result = xslt_executable.transform_to_string(source_file=tmp_xml_path)
 
-                # Parse result
-                if result:
-                    result_doc = etree.fromstring(result.encode("utf-8"))
-                    failed_asserts = result_doc.findall(".//{http://purl.oclc.org/dsdl/svrl}failed-assert")
-                    return failed_asserts
-                else:
-                    # No output means validation passed
+                if not result:
                     return []
 
-        # Temporary file automatically deleted when exiting context manager
-
-    except Exception as e:
-        if verbose:
-            print(f"✗ Error during Schematron validation: {e}")
-            import traceback
-
-            traceback.print_exc()
-        raise
+                result_doc = etree.fromstring(result.encode("utf-8"))
+                return _svrl_failed_asserts_to_violations(result_doc)

--- a/doclang/cli.py
+++ b/doclang/cli.py
@@ -14,6 +14,7 @@ import typer
 from doclang._schemas import _bundled_schema_paths
 from doclang.packaging import PackagingError
 from doclang.packaging import pack as pack_document
+from doclang.schematron import SchematronBackendNotFound
 from doclang.utils import _VERSION
 from doclang.validation import ValidationError
 from doclang.validation import validate as validate_document
@@ -77,6 +78,9 @@ def validate(
             xsd_only=xsd_only,
             schematron_only=schematron_only,
         )
+    except SchematronBackendNotFound as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
     except ValidationError as exc:
         results: dict[str, Any] = {
             "xsd": {"valid": not exc.xsd_errors, "errors": exc.xsd_errors},

--- a/doclang/doclang.sch
+++ b/doclang/doclang.sch
@@ -56,7 +56,8 @@
       <sch:let name="cell-tokens" value="dl:fcel | dl:ecel | dl:ched | dl:rhed | dl:corn | dl:srow | dl:lcel | dl:ucel | dl:xcel"/>
 
       <!-- Count cells in first row (before first nl) -->
-      <sch:let name="first-row-cells" value="count($cell-tokens[following-sibling::dl:nl[1] is current()/dl:nl[1]])"/>
+      <sch:let name="first-nl" value="dl:nl[1]"/>
+      <sch:let name="first-row-cells" value="count($cell-tokens[following-sibling::dl:nl[1] is $first-nl])"/>
 
       <!-- Check that all subsequent rows have the same number of cells -->
       <sch:assert test="every $nl in dl:nl[position() > 1] satisfies
@@ -109,7 +110,8 @@
 
   <sch:pattern id="xref-thread-defined">
     <sch:rule context="dl:xref">
-      <sch:assert test="exists(//dl:thread[@thread_id = current()/@thread_id])">
+      <sch:let name="thread-id" value="@thread_id"/>
+      <sch:assert test="exists(//dl:thread[@thread_id = $thread-id])">
         Element xref references thread_id="<sch:value-of select="@thread_id"/>" but no thread element defines that id.
       </sch:assert>
     </sch:rule>

--- a/doclang/schematron.py
+++ b/doclang/schematron.py
@@ -1,0 +1,58 @@
+"""Schematron validation plug-in interface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class SchematronViolation:
+    """A single Schematron rule failure."""
+
+    message: str
+    location: str | None = None
+    rule_id: str | None = None
+    test: str | None = None
+
+
+@runtime_checkable
+class SchematronValidator(Protocol):
+    """Validate DocLang XML against a Schematron schema."""
+
+    def validate(
+        self,
+        xml_path: Path,
+        *,
+        schema_path: Path,
+        allow_empty_namespace: bool = False,
+    ) -> list[SchematronViolation]:
+        """Return rule violations; an empty list means validation passed."""
+
+
+class SchematronBackendNotFound(ImportError):
+    """Raised when Schematron validation is requested but no backend is available."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Schematron validation requires a backend. Install doclang[schematron-saxon] "
+            "or pass schematron=YourValidator() to validate()."
+        )
+
+
+def _require_saxonche_backend() -> None:
+    """Raise SchematronBackendNotFound when the optional saxonche dependency is missing."""
+    try:
+        import saxonche  # noqa: F401
+    except ImportError as exc:
+        raise SchematronBackendNotFound() from exc
+
+
+def _default_schematron_validator() -> SchematronValidator:
+    _require_saxonche_backend()
+    try:
+        from doclang.backends.saxonche import SaxoncheValidator
+    except ImportError as exc:
+        raise SchematronBackendNotFound() from exc
+    return SaxoncheValidator()

--- a/doclang/schematron_validation.py
+++ b/doclang/schematron_validation.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Union
 
 from lxml import etree
-from saxonche import PySaxonProcessor
 
 from doclang._schemas import _bundled_sch_path
 from doclang.utils import _ensure_namespace
@@ -117,6 +116,13 @@ def _transpile_schematron_to_xslt(sch_file, verbose=False):
     if verbose:
         print(f"Transpiling Schematron: {sch_file}")
 
+    try:
+        from saxonche import PySaxonProcessor
+    except ImportError:
+        raise ImportError(
+            "saxonche is required for Schematron validation. Install it with: pip install doclang[schematron]"
+        ) from None
+
     with PySaxonProcessor(license=False) as proc:
         xslt_proc = proc.new_xslt30_processor()
 
@@ -162,6 +168,13 @@ def _validate_with_schematron(
             tmp_xml_path = tmp.name
 
             # File is still open but flushed, Saxon can read it
+            try:
+                from saxonche import PySaxonProcessor
+            except ImportError:
+                raise ImportError(
+                    "saxonche is required for Schematron validation. Install it with: pip install doclang[schematron]"
+                ) from None
+
             with PySaxonProcessor(license=False) as proc:
                 if verbose:
                     print(f"Using XSLT processor version: {proc.version}")

--- a/doclang/validation.py
+++ b/doclang/validation.py
@@ -3,23 +3,25 @@
 from pathlib import Path
 from typing import Any, Union
 
-from doclang.schematron_validation import _validate_with_schematron
+from doclang._schemas import _bundled_sch_path
+from doclang.schematron import (
+    SchematronBackendNotFound,
+    SchematronValidator,
+    SchematronViolation,
+    _default_schematron_validator,
+)
 from doclang.xsd_validation import _validate_xsd
 
-__all__ = ["ValidationError", "validate"]
-
-_SVRL_NS = "http://purl.oclc.org/dsdl/svrl"
+__all__ = ["SchematronBackendNotFound", "ValidationError", "validate"]
 
 
-def _failed_asserts_to_errors(failed_asserts: list) -> list[dict[str, Any]]:
+def _violations_to_errors(violations: list[SchematronViolation]) -> list[dict[str, Any]]:
     return [
         {
-            "location": assert_elem.get("location", "unknown"),
-            "message": assert_elem.find(f"{{{_SVRL_NS}}}text").text
-            if assert_elem.find(f"{{{_SVRL_NS}}}text") is not None
-            else "No message",
+            "location": violation.location or "unknown",
+            "message": violation.message,
         }
-        for assert_elem in failed_asserts
+        for violation in violations
     ]
 
 
@@ -61,10 +63,17 @@ def validate(
     allow_empty_namespace: bool = False,
     xsd_only: bool = False,
     schematron_only: bool = False,
+    schematron: SchematronValidator | None = None,
 ) -> None:
     """Validate a DocLang XML file using the bundled reference XSD and Schematron rules.
 
+    By default both XSD and Schematron validation run. Pass ``schematron`` to use a
+    custom Schematron backend; when omitted, the default Saxon/C backend is used
+    (requires ``doclang[schematron-saxon]``).
+
     Raises :class:`ValidationError` on failure.
+    Raises :class:`SchematronBackendNotFound` when Schematron validation is requested
+    but no backend is available.
     """
     path = Path(xml_file)
     xsd_errors: list[dict[str, Any]] = []
@@ -74,14 +83,17 @@ def validate(
         xsd_errors = _validate_xsd(path, allow_empty_namespace=allow_empty_namespace)
 
     if not xsd_only:
+        validator = schematron or _default_schematron_validator()
         try:
-            failed_asserts = _validate_with_schematron(
+            violations = validator.validate(
                 path,
+                schema_path=_bundled_sch_path(),
                 allow_empty_namespace=allow_empty_namespace,
-                verbose=False,
             )
-            if failed_asserts:
-                schematron_errors = _failed_asserts_to_errors(failed_asserts)
+            if violations:
+                schematron_errors = _violations_to_errors(violations)
+        except SchematronBackendNotFound:
+            raise
         except Exception as exc:
             schematron_errors = [{"error": str(exc)}]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,11 @@ classifiers = [
 ]
 dependencies = [
     "lxml>=6.0.2",
-    "saxonche>=12.9.0",
     "typer>=0.15.1",
 ]
+
+[project.optional-dependencies]
+schematron = ["saxonche>=12.9.0"]
 
 [project.urls]
 Homepage = "https://www.doclang.ai/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-schematron = ["saxonche>=12.9.0"]
+schematron-saxon = ["saxonche>=12.9.0"]
 
 [project.urls]
 Homepage = "https://www.doclang.ai/"
@@ -51,6 +51,7 @@ ci = [
     "ruff>=0.14.11",
     "pytest~=8.3",
     "python-docx>=1.2.0",
+    "saxonche>=12.9.0",
 ]
 dev = [
     { include-group = "ci" },
@@ -65,7 +66,7 @@ package = true
 default-groups = ["dev"]
 
 [tool.setuptools]
-packages = ["doclang"]
+packages = ["doclang", "doclang.backends"]
 
 [tool.ruff]
 target-version = "py310"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,12 +5,15 @@ Tests both valid and invalid XML documents against XSD and Schematron rules
 via the public ``validate()`` API.
 """
 
+import builtins
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 import doclang
-from doclang import ValidationError, validate
+from doclang import SchematronBackendNotFound, SchematronViolation, ValidationError, validate
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 VALID_DIR = TEST_DATA_DIR / "valid"
@@ -71,3 +74,44 @@ def test_test_directories_exist():
     assert INVALID_DIR.exists(), f"Invalid test directory not found: {INVALID_DIR}"
     assert len(valid_files) > 0, "No valid test files found"
     assert len(invalid_files) > 0, "No invalid test files found"
+
+
+class _AlwaysFailingSchematronValidator:
+    def validate(self, xml_path: Path, *, schema_path: Path, allow_empty_namespace: bool = False):
+        return [SchematronViolation(location="/doclang", message="custom backend failure")]
+
+
+def test_custom_schematron_validator():
+    """A caller-provided Schematron backend is used instead of the default."""
+    xml_file = valid_files[0]
+    with pytest.raises(ValidationError) as exc_info:
+        validate(xml_file, schematron=_AlwaysFailingSchematronValidator())
+
+    assert exc_info.value.schematron_errors == [{"location": "/doclang", "message": "custom backend failure"}]
+
+
+def test_schematron_backend_not_found():
+    """Missing default backend raises SchematronBackendNotFound."""
+    xml_file = valid_files[0]
+    with patch("doclang.validation._default_schematron_validator", side_effect=SchematronBackendNotFound):
+        with pytest.raises(SchematronBackendNotFound):
+            validate(xml_file, schematron_only=True)
+
+
+def test_schematron_backend_not_found_when_saxonche_missing():
+    """Missing saxonche extra raises SchematronBackendNotFound, not ValidationError."""
+    xml_file = valid_files[0]
+    real_import = builtins.__import__
+    saxonche_modules = [name for name in sys.modules if name == "saxonche" or name.startswith("saxonche.")]
+
+    def import_without_saxonche(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "saxonche" or name.startswith("saxonche."):
+            raise ModuleNotFoundError("No module named 'saxonche'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with (
+        patch.dict(sys.modules, dict.fromkeys(saxonche_modules)),
+        patch("builtins.__import__", side_effect=import_without_saxonche),
+    ):
+        with pytest.raises(SchematronBackendNotFound):
+            validate(xml_file, schematron_only=True)

--- a/uv.lock
+++ b/uv.lock
@@ -355,8 +355,12 @@ version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },
-    { name = "saxonche" },
     { name = "typer" },
+]
+
+[package.optional-dependencies]
+schematron = [
+    { name = "saxonche" },
 ]
 
 [package.dev-dependencies]
@@ -382,9 +386,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "lxml", specifier = ">=6.0.2" },
-    { name = "saxonche", specifier = ">=12.9.0" },
+    { name = "saxonche", marker = "extra == 'schematron'", specifier = ">=12.9.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
+provides-extras = ["schematron"]
 
 [package.metadata.requires-dev]
 ci = [

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-schematron = [
+schematron-saxon = [
     { name = "saxonche" },
 ]
 
@@ -370,6 +370,7 @@ ci = [
     { name = "pytest" },
     { name = "python-docx" },
     { name = "ruff" },
+    { name = "saxonche" },
 ]
 dev = [
     { name = "docling" },
@@ -381,15 +382,16 @@ dev = [
     { name = "python-docx" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "saxonche" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "lxml", specifier = ">=6.0.2" },
-    { name = "saxonche", marker = "extra == 'schematron'", specifier = ">=12.9.0" },
+    { name = "saxonche", marker = "extra == 'schematron-saxon'", specifier = ">=12.9.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
-provides-extras = ["schematron"]
+provides-extras = ["schematron-saxon"]
 
 [package.metadata.requires-dev]
 ci = [
@@ -398,6 +400,7 @@ ci = [
     { name = "pytest", specifier = "~=8.3" },
     { name = "python-docx", specifier = ">=1.2.0" },
     { name = "ruff", specifier = ">=0.14.11" },
+    { name = "saxonche", specifier = ">=12.9.0" },
 ]
 dev = [
     { name = "docling", specifier = ">=2.0.0" },
@@ -409,6 +412,7 @@ dev = [
     { name = "python-docx", specifier = ">=1.2.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", specifier = ">=0.14.11" },
+    { name = "saxonche", specifier = ">=12.9.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Introduce `SchematronValidator` protocol, `SchematronViolation`, and optional `schematron=` parameter on `validate()`
- Move Saxon/C implementation to `doclang.backends.saxonche` and make `saxonche` an optional `doclang[schematron-saxon]` extra
- Raise `SchematronBackendNotFound` when Schematron validation is requested without an installed backend
- Fix XPath in bundled `doclang.sch` for broader Schematron engine compatibility
- Document plugging in custom Schematron backends

BREAKING CHANGE: `saxonche` is no longer installed by default; install `doclang[schematron-saxon]` (or pass a custom `schematron=` backend) for Schematron validation.